### PR TITLE
Anpassung an MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ Es wird das Kommando "pstotext" benötigt, um es zu installieren, muss das folge
     pkg install print/pstotext
 
 --------------------------------------------------------------------------------
-Vorbereitungen/Installationen mit MacOS
+Vorbereitungen/Installationen mit MacOS 13
 --------------------------------------------
-**Nur 'postbank_pdf2csv.sk' v1.5.1(angepasst) getestet** 
+**Nur `postbank_pdf2csv.sh` angepasst/getestet**
 
-Die folgenden installation werden mit 'brew' durchgeführt. Anbei homepage https://brew.sh/index_de zur installation von 'brew'.
+Die folgenden Installationen werden mit [brew](https://brew.sh) durchgeführt.
 
-Optional: Wenn der Download der sourcen über wget erfolgen soll:
+Optional: Wenn der Download des Quellcodes über wget erfolgen soll:
 
-    brew install wget 
+    brew install wget
 
-Installation von gostscript
+Installation von ghostscript
 
     brew install ghostscript
 
-installation poppler für pstotext, pdftohtml, ...
+Installation von poppler für pstotext, pdftohtml usw.
 
     brew install poppler
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Es wird das Kommando "pstotext" benötigt, um es zu installieren, muss das folge
     pkg install print/pstotext
 
 --------------------------------------------------------------------------------
+Vorbereitungen/Installationen mit MacOS
+--------------------------------------------
+**Nur 'postbank_pdf2csv.sk' v1.5.1(angepasst) getestet** 
+
+Die folgenden installation werden mit 'brew' durchgeführt. Anbei homepage https://brew.sh/index_de zur installation von 'brew'.
+
+Optional: Wenn der Download der sourcen über wget erfolgen soll:
+
+    brew install wget 
+
+Installation von gostscript
+
+    brew install ghostscript
+
+installation poppler für pstotext, pdftohtml, ...
+
+    brew install poppler
+
+--------------------------------------------------------------------------------
 Ab Juli 2014:
 
 beispielsweise könnte man das so machen,

--- a/postbank_pdf2csv.sh
+++ b/postbank_pdf2csv.sh
@@ -37,12 +37,12 @@ fi
 #------------------------------------------------------------------------------#
 ### Betriebssystem-Werkzeug-Name setzen
 
-if [ "$(uname -o)" = "FreeBSD" ] ; then
+if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ]  ; then
         UMDREHEN="tail -r"
 elif [ "$(uname -o)" = "GNU/Linux" ] ; then
         UMDREHEN="tac"
 else
-        echo "Dieses Skript funktioniert nur mit FreeBSD und Linux."
+        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux or MacOS."
         exit 1
 fi
 

--- a/postbank_pdf2csv.sh
+++ b/postbank_pdf2csv.sh
@@ -37,12 +37,12 @@ fi
 #------------------------------------------------------------------------------#
 ### Betriebssystem-Werkzeug-Name setzen
 
-if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ]  ; then
+if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ] ; then
         UMDREHEN="tail -r"
 elif [ "$(uname -o)" = "GNU/Linux" ] ; then
         UMDREHEN="tac"
 else
-        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux or MacOS."
+        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux oder MacOS."
         exit 1
 fi
 

--- a/postbank_pdf2csv_bis_2017-06.sh
+++ b/postbank_pdf2csv_bis_2017-06.sh
@@ -36,12 +36,12 @@ fi
 #------------------------------------------------------------------------------#
 ### Betriebssystem-Werkzeug-Name setzen
 
-if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ]  ; then
+if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ] ; then
         UMDREHEN="tail -r"
 elif [ "$(uname -o)" = "GNU/Linux" ] ; then
         UMDREHEN="tac"
 else
-        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux or MacOS."
+        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux oder MacOS."
         exit 1
 fi
 

--- a/postbank_pdf2csv_bis_2017-06.sh
+++ b/postbank_pdf2csv_bis_2017-06.sh
@@ -36,12 +36,12 @@ fi
 #------------------------------------------------------------------------------#
 ### Betriebssystem-Werkzeug-Name setzen
 
-if [ "$(uname -o)" = "FreeBSD" ] ; then
+if [ "$(uname -o)" = "FreeBSD" ] || [ "$(uname -o)" = "Darwin" ]  ; then
         UMDREHEN="tail -r"
 elif [ "$(uname -o)" = "GNU/Linux" ] ; then
         UMDREHEN="tac"
 else
-        echo "Dieses Skript funktioniert nur mit FreeBSD und Linux."
+        echo "Dieses Skript funktioniert nur mit FreeBSD, Linux or MacOS."
         exit 1
 fi
 


### PR DESCRIPTION
Anbei Anpassung um dieses Skript auch für macOS nutzbar zu machen. 
Anpassung READE.me für notwendige Installationen. 

Auf MacOS 13.1 intel getestet.
Die notwendigen Installations Pakete sind auch für Apple Silicon verfügbar. Müsste auch gehen.